### PR TITLE
fix: Set go minimum version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matheusmosca/walrus
 
-go 1.17
+go 1.16
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
This repo supports Go version 1.16 and higher.
This change also solves the problem when running `go mod tidy` under version 1.17.