### PR TITLE
test: add unit tests for get_topic.go

### DIFF
--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -2,11 +2,11 @@ package topics
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/matheusmosca/walrus/domain/entities"
 	"github.com/matheusmosca/walrus/domain/vos"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +65,6 @@ func TestGetTopic_Negative(t *testing.T) {
 		args        args
 		beforeRun   func(storage map[vos.TopicName]entities.Topic)
 		wantErr     error
-		want        vos.TopicName
 	}
 
 	tests := []testCase{

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -69,7 +69,7 @@ func TestGetTopic_Negative(t *testing.T) {
 
 	tests := []testCase{
 		{
-			description: "The first negative topic",
+			description: "should return an error when topic is not found",
 			args: args{
 				topicName: vos.TopicName("neg_topic_1"),
 			},

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -56,7 +56,7 @@ func TestGetTopic_Success(t *testing.T) {
 	}
 }
 
-func TestGetTopic_Negative(t *testing.T) {
+func TestGetTopic_Failure(t *testing.T) {
 	type args struct {
 		topicName vos.TopicName
 	}

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -61,7 +61,6 @@ func TestGetTopic_Success(t *testing.T) {
 }
 
 func TestGetTopic_Negative(t *testing.T) {
-
 	// negativeTestcase neither creates a topic nor stores it in the repository.storage as a part of its beforeRun routine
 	// hence these test cases should run with negative results for GetTopic method
 	negativeTestcase := []testCase{

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -1,0 +1,91 @@
+package topics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matheusmosca/walrus/domain/entities"
+	"github.com/matheusmosca/walrus/domain/vos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTopic(t *testing.T) {
+	type args struct {
+		topicName vos.TopicName
+	}
+	type testCase struct {
+		description string
+		args        args
+		beforeRun   func(storage map[vos.TopicName]entities.Topic)
+		wantErr     error
+	}
+
+	// positiveTestcase creates a topic and stores it in the repository.storage as a part of its beforeRun routine
+	// hence these test cases should run with positive results for GetTopic method
+	positiveTestcase := []testCase{
+		{
+			description: "The first positive topic",
+			args: args{
+				topicName: vos.TopicName("pos_topic_1"),
+			},
+			beforeRun: func(storage map[vos.TopicName]entities.Topic) {
+				topicName := vos.TopicName("pos_topic_1")
+				topic, _ := entities.NewTopic(topicName)
+				storage[topicName] = topic
+			},
+			wantErr: entities.ErrTopicAlreadyExists,
+		},
+	}
+
+	for _, tt := range positiveTestcase {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+			storage := make(map[vos.TopicName]entities.Topic)
+			tt.beforeRun(storage)
+
+			newTopic, err := entities.NewTopic(tt.args.topicName)
+			require.NoError(t, err)
+			require.NotEqual(t, newTopic, entities.Topic{})
+
+			repository := NewMemoryRepository(storage)
+			getTopic, err := repository.GetTopic(context.TODO(), tt.args.topicName)
+
+			require.NoError(t, err)
+			require.NotEqual(t, getTopic, entities.Topic{})
+		})
+	}
+
+	// negativeTestcase neither creates a topic nor stores it in the repository.storage as a part of its beforeRun routine
+	// hence these test cases should run with negative results for GetTopic method
+	negativeTestcase := []testCase{
+		{
+			description: "The first negative topic",
+			args: args{
+				topicName: vos.TopicName("neg_topic_1"),
+			},
+			beforeRun: func(storage map[vos.TopicName]entities.Topic) {
+			},
+			wantErr: entities.ErrTopicAlreadyExists,
+		},
+	}
+
+	for _, tt := range negativeTestcase {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+			storage := make(map[vos.TopicName]entities.Topic)
+			tt.beforeRun(storage)
+
+			newTopic, err := entities.NewTopic(tt.args.topicName)
+			require.NoError(t, err)
+			require.NotEqual(t, newTopic, entities.Topic{})
+
+			repository := NewMemoryRepository(storage)
+			getTopic, err := repository.GetTopic(context.TODO(), tt.args.topicName)
+
+			require.Equal(t, err, entities.ErrTopicNotFound)
+			require.Equal(t, getTopic, entities.Topic{})
+		})
+	}
+}

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -10,20 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type args struct {
-	topicName vos.TopicName
-}
-type testCase struct {
-	description string
-	args        args
-	beforeRun   func(storage map[vos.TopicName]entities.Topic)
-	wantErr     error
-}
-
 func TestGetTopic_Success(t *testing.T) {
-	// positiveTestcase creates a topic and stores it in the repository.storage as a part of its beforeRun routine
-	// hence these test cases should run with positive results for GetTopic method
-	positiveTestcase := []testCase{
+	type args struct {
+		topicName vos.TopicName
+	}
+	type testCase struct {
+		description string
+		args        args
+		beforeRun   func(storage map[vos.TopicName]entities.Topic)
+		wantErr     error
+	}
+
+	tests := []testCase{
 		{
 			description: "The first positive topic",
 			args: args{
@@ -38,7 +36,7 @@ func TestGetTopic_Success(t *testing.T) {
 		},
 	}
 
-	for _, tt := range positiveTestcase {
+	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
@@ -52,18 +50,25 @@ func TestGetTopic_Success(t *testing.T) {
 			repository := NewMemoryRepository(storage)
 			getTopic, err := repository.GetTopic(context.TODO(), tt.args.topicName)
 
-			if tt.wantErr == nil {
-				require.NoError(t, err)
-			}
+			assert.ErrorIs(t, err, tt.wantErr)
 			assert.NotEmpty(t, getTopic)
 		})
 	}
 }
 
 func TestGetTopic_Negative(t *testing.T) {
-	// negativeTestcase neither creates a topic nor stores it in the repository.storage as a part of its beforeRun routine
-	// hence these test cases should run with negative results for GetTopic method
-	negativeTestcase := []testCase{
+	type args struct {
+		topicName vos.TopicName
+	}
+	type testCase struct {
+		description string
+		args        args
+		beforeRun   func(storage map[vos.TopicName]entities.Topic)
+		wantErr     error
+		want        vos.TopicName
+	}
+
+	tests := []testCase{
 		{
 			description: "The first negative topic",
 			args: args{
@@ -75,7 +80,7 @@ func TestGetTopic_Negative(t *testing.T) {
 		},
 	}
 
-	for _, tt := range negativeTestcase {
+	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
@@ -89,9 +94,7 @@ func TestGetTopic_Negative(t *testing.T) {
 			repository := NewMemoryRepository(storage)
 			getTopic, err := repository.GetTopic(context.TODO(), tt.args.topicName)
 
-			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
-			}
+			assert.ErrorIs(t, err, tt.wantErr)
 			assert.Empty(t, getTopic)
 		})
 	}

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type args struct {
-	topicName vos.TopicName
-}
-type testCase struct {
-	description string
-	args        args
-	beforeRun   func(storage map[vos.TopicName]entities.Topic)
-	wantErr     error
-}
-
 func TestGetTopic_Success(t *testing.T) {
+	type args struct {
+		topicName vos.TopicName
+	}
+	type testCase struct {
+		description string
+		args        args
+		beforeRun   func(storage map[vos.TopicName]entities.Topic)
+		wantErr     error
+	}
+
 	tests := []testCase{
 		{
 			description: "The first positive topic",
@@ -50,13 +50,23 @@ func TestGetTopic_Success(t *testing.T) {
 			repository := NewMemoryRepository(storage)
 			getTopic, err := repository.GetTopic(context.TODO(), tt.args.topicName)
 
-			assert.ErrorIs(t, err, tt.wantErr)
 			assert.NotEmpty(t, getTopic)
+			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }
 
 func TestGetTopic_Negative(t *testing.T) {
+	type args struct {
+		topicName vos.TopicName
+	}
+	type testCase struct {
+		description string
+		args        args
+		beforeRun   func(storage map[vos.TopicName]entities.Topic)
+		wantErr     error
+	}
+
 	tests := []testCase{
 		{
 			description: "The first negative topic",

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -17,7 +17,6 @@ func TestGetTopic(t *testing.T) {
 		description string
 		args        args
 		beforeRun   func(storage map[vos.TopicName]entities.Topic)
-		wantErr     error
 	}
 
 	// positiveTestcase creates a topic and stores it in the repository.storage as a part of its beforeRun routine
@@ -33,7 +32,6 @@ func TestGetTopic(t *testing.T) {
 				topic, _ := entities.NewTopic(topicName)
 				storage[topicName] = topic
 			},
-			wantErr: entities.ErrTopicAlreadyExists,
 		},
 	}
 
@@ -66,7 +64,6 @@ func TestGetTopic(t *testing.T) {
 			},
 			beforeRun: func(storage map[vos.TopicName]entities.Topic) {
 			},
-			wantErr: entities.ErrTopicAlreadyExists,
 		},
 	}
 

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetTopic_Success(t *testing.T) {
-	type args struct {
-		topicName vos.TopicName
-	}
-	type testCase struct {
-		description string
-		args        args
-		beforeRun   func(storage map[vos.TopicName]entities.Topic)
-		wantErr     error
-	}
+type args struct {
+	topicName vos.TopicName
+}
+type testCase struct {
+	description string
+	args        args
+	beforeRun   func(storage map[vos.TopicName]entities.Topic)
+	wantErr     error
+}
 
+func TestGetTopic_Success(t *testing.T) {
 	tests := []testCase{
 		{
 			description: "The first positive topic",
@@ -57,16 +57,6 @@ func TestGetTopic_Success(t *testing.T) {
 }
 
 func TestGetTopic_Negative(t *testing.T) {
-	type args struct {
-		topicName vos.TopicName
-	}
-	type testCase struct {
-		description string
-		args        args
-		beforeRun   func(storage map[vos.TopicName]entities.Topic)
-		wantErr     error
-	}
-
 	tests := []testCase{
 		{
 			description: "The first negative topic",

--- a/repositories/memory/topics/get_topic_test.go
+++ b/repositories/memory/topics/get_topic_test.go
@@ -23,7 +23,7 @@ func TestGetTopic_Success(t *testing.T) {
 
 	tests := []testCase{
 		{
-			description: "The first positive topic",
+			description: "should return a topic without error",
 			args: args{
 				topicName: vos.TopicName("pos_topic_1"),
 			},


### PR DESCRIPTION
This PR adds support to test the scenarios present in the get_topic.go in terms of positive and negative test cases to handle some coverage for the method in get_topic.go, specifically GetTopic.

To run, 
1. Either use your IDE to directly run the method present in the file get_topic_test.go
2. Or use the traditional way using the command: `go test repositories/memory/topics -run TestGetTopic`