### PR TITLE
test: add unit tests for subscribe use case

### DIFF
--- a/domain/usecases/subscribe_test.go
+++ b/domain/usecases/subscribe_test.go
@@ -96,6 +96,7 @@ func TestSubscribe(t *testing.T) {
 
 				return repoMock, topic
 			},
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/domain/usecases/subscribe_test.go
+++ b/domain/usecases/subscribe_test.go
@@ -3,7 +3,6 @@ package usecases
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/matheusmosca/walrus/domain/entities"
 	"github.com/matheusmosca/walrus/domain/vos"
@@ -21,11 +20,10 @@ func TestSubscribe(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		args        args
-		fields      func(t *testing.T) (Repository, entities.Topic)
-		wantMessage vos.Message
-		wantErr     error
+		name    string
+		args    args
+		fields  func(t *testing.T) (Repository, entities.Topic)
+		wantErr error
 	}{
 		{
 			name: "subscribe should succeed",
@@ -50,11 +48,6 @@ func TestSubscribe(t *testing.T) {
 
 				return repoMock, topic
 			},
-			wantMessage: vos.Message{
-				TopicName:   vos.TopicName("walrus"),
-				PublishedBy: "test_publisher",
-				Body:        []byte("hello world"),
-			},
 			wantErr: nil,
 		},
 		{
@@ -64,9 +57,8 @@ func TestSubscribe(t *testing.T) {
 				topicName: "xy",
 				message:   vos.Message{},
 			},
-			fields:      func(t *testing.T) (Repository, entities.Topic) { return &RepositoryMock{}, entities.Topic{} },
-			wantMessage: vos.Message{},
-			wantErr:     vos.ErrTopicNameTooShort,
+			fields:  func(t *testing.T) (Repository, entities.Topic) { return &RepositoryMock{}, entities.Topic{} },
+			wantErr: vos.ErrTopicNameTooShort,
 		},
 		{
 			name: "empty topic name message should return error",
@@ -75,9 +67,8 @@ func TestSubscribe(t *testing.T) {
 				topicName: "",
 				message:   vos.Message{},
 			},
-			fields:      func(t *testing.T) (Repository, entities.Topic) { return &RepositoryMock{}, entities.Topic{} },
-			wantMessage: vos.Message{},
-			wantErr:     vos.ErrEmptyTopicName,
+			fields:  func(t *testing.T) (Repository, entities.Topic) { return &RepositoryMock{}, entities.Topic{} },
+			wantErr: vos.ErrEmptyTopicName,
 		},
 		{
 			name: "nonexistent topic subscribe should succeed",
@@ -127,15 +118,6 @@ func TestSubscribe(t *testing.T) {
 			defer close(subCh)
 
 			assert.NotEmpty(t, id)
-
-			go func() {
-				time.Sleep(time.Millisecond * 4)
-				err = topic.Dispatch(tt.args.message)
-				require.NoError(t, err)
-			}()
-
-			gotMessage := <-subCh
-			assert.Equal(t, tt.wantMessage, gotMessage)
 		})
 	}
 }

--- a/domain/usecases/subscribe_test.go
+++ b/domain/usecases/subscribe_test.go
@@ -1,0 +1,146 @@
+package usecases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matheusmosca/walrus/domain/entities"
+	"github.com/matheusmosca/walrus/domain/vos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubsribe(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		ctx       context.Context
+		topicName vos.TopicName
+	}
+
+	type fields struct {
+		storage   Repository
+		topicName vos.TopicName
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		fields  fields
+		wantCh  chan vos.Message
+		wantId  vos.SubscriberID
+		wantErr error
+	}{
+		{
+			name: "subscribe should succeed",
+			args: args{
+				ctx:       context.Background(),
+				topicName: "walrus",
+			},
+			fields: fields{
+				storage:   &RepositoryMock{},
+				topicName: "walrus",
+			},
+			wantCh:  make(chan vos.Message),
+			wantId:  vos.SubscriberID("id"),
+			wantErr: nil,
+		},
+		{
+			name: "short topic name should return error",
+			args: args{
+				ctx:       context.Background(),
+				topicName: "xd",
+			},
+			fields: fields{
+				storage:   &RepositoryMock{},
+				topicName: "walrus",
+			},
+			wantCh:  nil,
+			wantId:  "",
+			wantErr: vos.ErrTopicNameTooShort,
+		},
+		{
+			name: "empty topic name message should return error",
+			args: args{
+				ctx:       context.Background(),
+				topicName: "",
+			},
+			fields: fields{
+				storage:   &RepositoryMock{},
+				topicName: "walrus",
+			},
+			wantCh:  nil,
+			wantId:  "",
+			wantErr: vos.ErrEmptyTopicName,
+		},
+		{
+			name: "nonexistent topic should return error",
+			args: args{
+				ctx:       context.Background(),
+				topicName: "testtopic",
+			},
+			fields: fields{
+				storage:   &RepositoryMock{},
+				topicName: "walrus",
+			},
+			wantCh:  nil,
+			wantId:  "",
+			wantErr: entities.ErrTopicNotFound,
+		},
+		{
+			name: "topic already exists should return error",
+			args: args{
+				ctx:       context.Background(),
+				topicName: "walrus",
+			},
+			fields: fields{
+				storage:   &RepositoryMock{},
+				topicName: "walrus",
+			},
+			wantCh:  nil,
+			wantId:  "",
+			wantErr: entities.ErrTopicNotFound,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// init the topic
+			topic, err := entities.NewTopic(tt.fields.topicName)
+			require.NoError(t, err)
+
+			// activate the topic
+			topic.Activate()
+
+			tt.fields.storage = &RepositoryMock{
+				GetTopicFunc: func(ctx context.Context, topicName vos.TopicName) (entities.Topic, error) {
+					if tt.fields.topicName != tt.args.topicName {
+						return entities.Topic{}, entities.ErrTopicNotFound
+					}
+
+					return topic, nil
+				},
+				CreateTopicFunc: func(ctx context.Context, topicName vos.TopicName, topic entities.Topic) error {
+					if tt.fields.topicName == tt.args.topicName {
+						return entities.ErrTopicAlreadyExists
+					}
+
+					return nil
+				},
+			}
+
+			useCase := New(tt.fields.storage)
+			subCh, id, err := useCase.Subscribe(tt.args.ctx, tt.args.topicName)
+			if err != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.IsType(t, tt.wantCh, subCh)
+			assert.IsType(t, tt.wantId, id)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a testing scenario for use case subscribe.

closes #9 